### PR TITLE
Refactor dashboard shell into modular sections

### DIFF
--- a/components/dashboard/campaign-create-card.tsx
+++ b/components/dashboard/campaign-create-card.tsx
@@ -1,0 +1,69 @@
+"use client";
+
+import type { FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+
+interface CampaignCreateCardProps {
+  isOpen: boolean;
+  hasCampaigns: boolean;
+  name: string;
+  onNameChange: (value: string) => void;
+  onToggle: () => void;
+  onSubmit: (event: FormEvent<HTMLFormElement>) => void;
+  isSubmitting: boolean;
+  error: string | null;
+}
+
+export function CampaignCreateCard({
+  isOpen,
+  hasCampaigns,
+  name,
+  onNameChange,
+  onToggle,
+  onSubmit,
+  isSubmitting,
+  error
+}: CampaignCreateCardProps) {
+  return (
+    <Card className="border border-slate-800/80 bg-slate-900/60">
+      <CardHeader className="mb-4 flex-col items-start gap-3">
+        <div className="space-y-1">
+          <CardTitle>Start a new campaign</CardTitle>
+          <CardDescription>
+            {hasCampaigns
+              ? "Spin up another world to organise quests, notes, and NPCs."
+              : "Give your table a shared home for quests, notes, and NPCs."}
+          </CardDescription>
+        </div>
+        <Button type="button" onClick={onToggle} variant={isOpen ? "secondary" : "primary"} size="sm" disabled={isSubmitting}>
+          {isOpen ? "Cancel" : "New campaign"}
+        </Button>
+      </CardHeader>
+      {isOpen ? (
+        <form className="space-y-3" onSubmit={onSubmit}>
+          <div className="space-y-1 text-sm">
+            <label htmlFor="campaign-name" className="text-xs uppercase tracking-wide text-slate-400">
+              Campaign name
+            </label>
+            <Input
+              id="campaign-name"
+              placeholder="E.g. The Starfall Expedition"
+              value={name}
+              onChange={(event) => onNameChange(event.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          {error ? <p className="text-xs text-rose-400">{error}</p> : null}
+          <div className="flex justify-end">
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Creating..." : "Create campaign"}
+            </Button>
+          </div>
+        </form>
+      ) : null}
+    </Card>
+  );
+}

--- a/components/dashboard/campaign-resource-grid.tsx
+++ b/components/dashboard/campaign-resource-grid.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import type { Location, Note, Npc, Pc, Quest } from "@/types/database";
+
+import type { EncounterWithMonsters } from "./types";
+import { EncountersSection } from "./sections/encounters-section";
+import { LocationsSection } from "./sections/locations-section";
+import { NpcsSection } from "./sections/npcs-section";
+import { PlayerCharactersSection } from "./sections/player-characters-section";
+import { QuestsSection } from "./sections/quests-section";
+import { SessionTracker } from "./sections/session-tracker";
+
+interface CampaignResourceGridProps {
+  campaignId: string;
+  canManage: boolean;
+  notes: Note[];
+  pcs: Pc[];
+  npcs: Npc[];
+  quests: Quest[];
+  locations: Location[];
+  encounters: EncounterWithMonsters[];
+  onMutated: () => void;
+}
+
+export function CampaignResourceGrid({
+  campaignId,
+  canManage,
+  notes,
+  pcs,
+  npcs,
+  quests,
+  locations,
+  encounters,
+  onMutated
+}: CampaignResourceGridProps) {
+  const locationLookup = new Map(locations.map((location) => [location.id, location.name] as const));
+
+  return (
+    <div className="space-y-8">
+      <SessionTracker
+        campaignId={campaignId}
+        canManage={canManage}
+        notes={notes}
+        locations={locations}
+        locationLookup={locationLookup}
+        onMutated={onMutated}
+      />
+      <div className="grid gap-6 lg:grid-cols-2">
+        <PlayerCharactersSection campaignId={campaignId} canManage={canManage} pcs={pcs} onMutated={onMutated} />
+        <NpcsSection
+          campaignId={campaignId}
+          canManage={canManage}
+          npcs={npcs}
+          locations={locations}
+          locationLookup={locationLookup}
+          onMutated={onMutated}
+        />
+      </div>
+      <div className="grid gap-6 lg:grid-cols-2">
+        <LocationsSection campaignId={campaignId} canManage={canManage} locations={locations} onMutated={onMutated} />
+        <QuestsSection
+          campaignId={campaignId}
+          canManage={canManage}
+          quests={quests}
+          locations={locations}
+          locationLookup={locationLookup}
+          onMutated={onMutated}
+        />
+      </div>
+      <EncountersSection
+        campaignId={campaignId}
+        canManage={canManage}
+        encounters={encounters}
+        onMutated={onMutated}
+      />
+    </div>
+  );
+}

--- a/components/dashboard/empty-state-message.tsx
+++ b/components/dashboard/empty-state-message.tsx
@@ -1,0 +1,13 @@
+"use client";
+
+interface EmptyStateMessageProps {
+  message: string;
+}
+
+export function EmptyStateMessage({ message }: EmptyStateMessageProps) {
+  return (
+    <p className="rounded-lg border border-dashed border-slate-800 bg-slate-900/40 p-4 text-center text-sm text-slate-500">
+      {message}
+    </p>
+  );
+}

--- a/components/dashboard/sections/encounters-section.tsx
+++ b/components/dashboard/sections/encounters-section.tsx
@@ -1,0 +1,208 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
+import { Textarea } from "@/components/ui/textarea";
+import { postJson } from "@/lib/api";
+import type { Encounter } from "@/types/database";
+
+import { EmptyStateMessage } from "../empty-state-message";
+import type { EncounterWithMonsters } from "@/components/dashboard/types";
+
+import { selectClassName } from "./shared";
+
+interface EncountersSectionProps {
+  campaignId: string;
+  canManage: boolean;
+  encounters: EncounterWithMonsters[];
+  onMutated: () => void;
+}
+
+export function EncountersSection({ campaignId, canManage, encounters, onMutated }: EncountersSectionProps) {
+  const [name, setName] = useState("");
+  const [summary, setSummary] = useState("");
+  const [status, setStatus] = useState<Encounter["status"]>("draft");
+  const [round, setRound] = useState("1");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const encounterStatuses: Array<Encounter["status"]> = ["draft", "active", "completed"];
+
+  const resetForm = () => {
+    setName("");
+    setSummary("");
+    setStatus("draft");
+    setRound("1");
+    setError(null);
+  };
+
+  const handleModalClose = () => {
+    if (isSubmitting) {
+      return;
+    }
+    setIsModalOpen(false);
+    resetForm();
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!name.trim()) {
+      setError("Name your encounter to continue.");
+      return;
+    }
+
+    const roundValue = round.trim() ? Number.parseInt(round, 10) : undefined;
+
+    if (roundValue !== undefined && (Number.isNaN(roundValue) || roundValue < 1)) {
+      setError("Set a round number of 1 or higher.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await postJson(`/api/campaigns/${campaignId}/encounters`, {
+        name: name.trim(),
+        summary: summary.trim(),
+        status,
+        round: roundValue
+      });
+
+      onMutated();
+      setIsModalOpen(false);
+      resetForm();
+    } catch (encounterError) {
+      setError(encounterError instanceof Error ? encounterError.message : "Unable to save encounter");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Card className="bg-slate-900/60">
+        <CardHeader className="mb-4 flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <CardTitle>Encounters</CardTitle>
+            <CardDescription>Prep combat and set-piece moments.</CardDescription>
+          </div>
+          {canManage ? (
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => {
+                setError(null);
+                setIsModalOpen(true);
+              }}
+            >
+              Add encounter
+            </Button>
+          ) : null}
+        </CardHeader>
+        <div className="space-y-4">
+          {canManage ? null : (
+            <p className="rounded-md border border-dashed border-slate-800 bg-slate-900/40 p-3 text-xs text-slate-500">
+              Only campaign owners and co-DMs can add encounters.
+            </p>
+          )}
+          <div className="space-y-3 text-sm text-slate-300">
+            {encounters.length === 0 ? (
+              <EmptyStateMessage message="No encounters prepped yet." />
+            ) : (
+              encounters.map((encounter) => (
+                <div key={encounter.id} className="space-y-2 rounded-lg border border-slate-800 bg-slate-950/60 p-4">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-medium text-slate-100">{encounter.name}</p>
+                    <span className="text-xs uppercase tracking-wide text-slate-500">{encounter.status}</span>
+                  </div>
+                  {encounter.summary ? <p className="text-xs text-slate-500">{encounter.summary}</p> : null}
+                  <p className="text-xs text-slate-500">
+                    {encounter.encounter_monsters.length} creature{encounter.encounter_monsters.length === 1 ? "" : "s"} • Round
+                    {encounter.round ?? 1}
+                  </p>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </Card>
+      <Modal open={isModalOpen} onClose={handleModalClose} title="Add encounter">
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="space-y-1 text-sm">
+            <label htmlFor="encounter-name" className="text-xs uppercase tracking-wide text-slate-400">
+              Name
+            </label>
+            <Input
+              id="encounter-name"
+              placeholder="E.g. Ambush at Dawnspire"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="space-y-1 text-sm">
+            <label htmlFor="encounter-summary" className="text-xs uppercase tracking-wide text-slate-400">
+              Summary
+            </label>
+            <Textarea
+              id="encounter-summary"
+              placeholder="Victory conditions, enemy tactics, terrain twists."
+              value={summary}
+              onChange={(event) => setSummary(event.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1 text-sm">
+              <label htmlFor="encounter-status" className="text-xs uppercase tracking-wide text-slate-400">
+                Status
+              </label>
+              <select
+                id="encounter-status"
+                className={selectClassName}
+                value={status}
+                onChange={(event) => setStatus(event.target.value as Encounter["status"])}
+                disabled={isSubmitting}
+              >
+                {encounterStatuses.map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-1 text-sm">
+              <label htmlFor="encounter-round" className="text-xs uppercase tracking-wide text-slate-400">
+                Current round
+              </label>
+              <Input
+                id="encounter-round"
+                type="number"
+                min={1}
+                value={round}
+                onChange={(event) => setRound(event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+          </div>
+          {error ? <p className="text-xs text-rose-400">{error}</p> : null}
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="secondary" onClick={handleModalClose} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Saving..." : "Save encounter"}
+            </Button>
+          </div>
+        </form>
+      </Modal>
+    </>
+  );
+}

--- a/components/dashboard/sections/locations-section.tsx
+++ b/components/dashboard/sections/locations-section.tsx
@@ -1,0 +1,136 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { postJson } from "@/lib/api";
+import type { Location } from "@/types/database";
+
+import { EmptyStateMessage } from "../empty-state-message";
+
+interface LocationsSectionProps {
+  campaignId: string;
+  canManage: boolean;
+  locations: Location[];
+  onMutated: () => void;
+}
+
+export function LocationsSection({ campaignId, canManage, locations, onMutated }: LocationsSectionProps) {
+  const [name, setName] = useState("");
+  const [typeValue, setTypeValue] = useState("");
+  const [description, setDescription] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!name.trim()) {
+      setError("Name your location before saving.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await postJson(`/api/campaigns/${campaignId}/locations`, {
+        name: name.trim(),
+        type: typeValue.trim(),
+        description: description.trim()
+      });
+
+      setName("");
+      setTypeValue("");
+      setDescription("");
+      onMutated();
+    } catch (locationError) {
+      setError(locationError instanceof Error ? locationError.message : "Unable to save location");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Card className="bg-slate-900/60">
+      <CardHeader className="mb-4 flex-col items-start gap-1">
+        <div>
+          <CardTitle>Locations</CardTitle>
+          <CardDescription>Map key places your party visits.</CardDescription>
+        </div>
+      </CardHeader>
+      <div className="space-y-4">
+        {canManage ? (
+          <form className="space-y-3" onSubmit={handleSubmit}>
+            <div className="space-y-1 text-sm">
+              <label htmlFor="location-name" className="text-xs uppercase tracking-wide text-slate-400">
+                Name
+              </label>
+              <Input
+                id="location-name"
+                placeholder="E.g. The Gilded Griffin"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+            <div className="space-y-1 text-sm">
+              <label htmlFor="location-type" className="text-xs uppercase tracking-wide text-slate-400">
+                Type (optional)
+              </label>
+              <Input
+                id="location-type"
+                placeholder="City, Tavern, Ruins..."
+                value={typeValue}
+                onChange={(event) => setTypeValue(event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+            <div className="space-y-1 text-sm">
+              <label htmlFor="location-description" className="text-xs uppercase tracking-wide text-slate-400">
+                Description
+              </label>
+              <Textarea
+                id="location-description"
+                placeholder="Lore, vibes, or notable NPCs."
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+            {error ? <p className="text-xs text-rose-400">{error}</p> : null}
+            <div className="flex justify-end">
+              <Button type="submit" disabled={isSubmitting}>
+                {isSubmitting ? "Saving..." : "Add location"}
+              </Button>
+            </div>
+          </form>
+        ) : (
+          <p className="rounded-md border border-dashed border-slate-800 bg-slate-900/40 p-3 text-xs text-slate-500">
+            Only campaign owners and co-DMs can add locations.
+          </p>
+        )}
+        <div className="space-y-3 text-sm text-slate-300">
+          {locations.length === 0 ? (
+            <EmptyStateMessage message="No locations logged yet." />
+          ) : (
+            locations.map((location) => (
+              <div key={location.id} className="space-y-1 rounded-lg border border-slate-800 bg-slate-950/60 p-4">
+                <div className="flex items-center justify-between">
+                  <p className="text-sm font-medium text-slate-100">{location.name}</p>
+                  {location.type ? (
+                    <span className="text-xs uppercase tracking-wide text-slate-500">{location.type}</span>
+                  ) : null}
+                </div>
+                {location.description ? <p className="text-xs text-slate-500">{location.description}</p> : null}
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </Card>
+  );
+}

--- a/components/dashboard/sections/npcs-section.tsx
+++ b/components/dashboard/sections/npcs-section.tsx
@@ -1,0 +1,268 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
+import { Textarea } from "@/components/ui/textarea";
+import { postJson } from "@/lib/api";
+import type { Location, Npc } from "@/types/database";
+
+import { EmptyStateMessage } from "../empty-state-message";
+
+import { selectClassName } from "./shared";
+
+interface NpcsSectionProps {
+  campaignId: string;
+  canManage: boolean;
+  npcs: Npc[];
+  locations: Location[];
+  locationLookup: Map<string, string>;
+  onMutated: () => void;
+}
+
+export function NpcsSection({ campaignId, canManage, npcs, locations, locationLookup, onMutated }: NpcsSectionProps) {
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [quirks, setQuirks] = useState("");
+  const [locationId, setLocationId] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const resetForm = () => {
+    setName("");
+    setDescription("");
+    setQuirks("");
+    setLocationId("");
+    setError(null);
+  };
+
+  const handleModalClose = () => {
+    if (isSubmitting) {
+      return;
+    }
+    setIsModalOpen(false);
+    resetForm();
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!name.trim()) {
+      setError("Enter an NPC name.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await postJson(`/api/campaigns/${campaignId}/npcs`, {
+        name: name.trim(),
+        description: description.trim(),
+        quirks: quirks.trim(),
+        location_id: locationId ? locationId : null
+      });
+
+      onMutated();
+      setIsModalOpen(false);
+      resetForm();
+    } catch (npcError) {
+      setError(npcError instanceof Error ? npcError.message : "Unable to add NPC");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleGenerate = () => {
+    const npc = generateRandomNpc();
+    setName(npc.name);
+    setDescription(npc.description);
+    setQuirks(npc.quirks);
+    setError(null);
+  };
+
+  return (
+    <>
+      <Card className="bg-slate-900/60">
+        <CardHeader className="mb-4 flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <CardTitle>NPCs</CardTitle>
+            <CardDescription>Keep personalities and plot hooks handy.</CardDescription>
+          </div>
+          {canManage ? (
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => {
+                setError(null);
+                setIsModalOpen(true);
+              }}
+            >
+              Add NPC
+            </Button>
+          ) : null}
+        </CardHeader>
+        <div className="space-y-4">
+          {canManage ? null : (
+            <p className="rounded-md border border-dashed border-slate-800 bg-slate-900/40 p-3 text-xs text-slate-500">
+              Only campaign owners and co-DMs can add NPCs.
+            </p>
+          )}
+          <div className="space-y-3 text-sm text-slate-300">
+            {npcs.length === 0 ? (
+              <EmptyStateMessage message="No NPCs saved yet." />
+            ) : (
+              npcs.map((npc) => (
+                <div key={npc.id} className="space-y-2 rounded-lg border border-slate-800 bg-slate-950/60 p-4">
+                  <div className="flex items-center justify-between">
+                    <p className="text-sm font-medium text-slate-100">{npc.name}</p>
+                    {npc.location_id ? (
+                      <span className="text-xs uppercase tracking-wide text-slate-500">
+                        {locationLookup.get(npc.location_id) ?? "Unknown locale"}
+                      </span>
+                    ) : null}
+                  </div>
+                  {npc.description ? <p className="text-xs text-slate-500">{npc.description}</p> : null}
+                  {npc.quirks ? <p className="text-xs text-slate-500">Quirks: {npc.quirks}</p> : null}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </Card>
+      <Modal open={isModalOpen} onClose={handleModalClose} title="Add NPC">
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-xs text-slate-500">Need inspiration? Generate a prompt.</p>
+            <Button type="button" variant="secondary" size="sm" onClick={handleGenerate} disabled={isSubmitting}>
+              Surprise me
+            </Button>
+          </div>
+          <div className="space-y-1 text-sm">
+            <label htmlFor="npc-name" className="text-xs uppercase tracking-wide text-slate-400">
+              Name
+            </label>
+            <Input
+              id="npc-name"
+              placeholder="E.g. Magistrate Velen"
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="space-y-1 text-sm">
+            <label htmlFor="npc-description" className="text-xs uppercase tracking-wide text-slate-400">
+              Description
+            </label>
+            <Textarea
+              id="npc-description"
+              placeholder="Role, appearance, or motivations."
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="space-y-1 text-sm">
+            <label htmlFor="npc-quirks" className="text-xs uppercase tracking-wide text-slate-400">
+              Quirks (optional)
+            </label>
+            <Input
+              id="npc-quirks"
+              placeholder="E.g. speaks in rhyme, collects odd trinkets"
+              value={quirks}
+              onChange={(event) => setQuirks(event.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="space-y-1 text-sm">
+            <label htmlFor="npc-location" className="text-xs uppercase tracking-wide text-slate-400">
+              Linked location
+            </label>
+            <select
+              id="npc-location"
+              className={selectClassName}
+              value={locationId}
+              onChange={(event) => setLocationId(event.target.value)}
+              disabled={isSubmitting}
+            >
+              <option value="">No location</option>
+              {locations.map((location) => (
+                <option key={location.id} value={location.id}>
+                  {location.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          {error ? <p className="text-xs text-rose-400">{error}</p> : null}
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="secondary" onClick={handleModalClose} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Saving..." : "Save NPC"}
+            </Button>
+          </div>
+        </form>
+      </Modal>
+    </>
+  );
+}
+
+const npcFirstNames = [
+  "Arin",
+  "Bryn",
+  "Cael",
+  "Dorian",
+  "Elowen",
+  "Fira",
+  "Galen",
+  "Hesta",
+  "Iris",
+  "Jorah"
+] as const;
+
+const npcLastNames = [
+  "Ashgrove",
+  "Brightwater",
+  "Duskvale",
+  "Emberfall",
+  "Frostwind",
+  "Mooncrest",
+  "Nightbloom",
+  "Stormfen",
+  "Thorne",
+  "Willowmere"
+] as const;
+
+const npcDescriptions = [
+  "A veteran scout who knows every hidden path around the region.",
+  "A charming innkeeper with a ledger of favors owed and collected.",
+  "A reclusive sage obsessed with celestial omens.",
+  "A merchant prince whose smile never reaches their eyes.",
+  "A bright-eyed acolyte carrying messages for a secretive order."
+] as const;
+
+const npcQuirkIdeas = [
+  "Collects buttons from every traveler they meet",
+  "Finishes every sentence with an optimistic proverb",
+  "Keeps an invisible 'pet' dragonling they insist is real",
+  "Refuses to speak above a whisper unless reciting poetry",
+  "Always hums the same three-note tune when thinking"
+] as const;
+
+function pickRandom<T>(values: readonly T[]): T {
+  return values[Math.floor(Math.random() * values.length)];
+}
+
+function generateRandomNpc() {
+  const name = `${pickRandom(npcFirstNames)} ${pickRandom(npcLastNames)}`;
+  return {
+    name,
+    description: pickRandom(npcDescriptions),
+    quirks: pickRandom(npcQuirkIdeas)
+  };
+}

--- a/components/dashboard/sections/player-characters-section.tsx
+++ b/components/dashboard/sections/player-characters-section.tsx
@@ -1,0 +1,269 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
+import { postJson } from "@/lib/api";
+import { getPcHealth } from "@/lib/campaign-utils";
+import type { Pc } from "@/types/database";
+
+import { EmptyStateMessage } from "../empty-state-message";
+
+interface PlayerCharactersSectionProps {
+  campaignId: string;
+  canManage: boolean;
+  pcs: Pc[];
+  onMutated: () => void;
+}
+
+export function PlayerCharactersSection({ campaignId, canManage, pcs, onMutated }: PlayerCharactersSectionProps) {
+  const [name, setName] = useState("");
+  const [characterClass, setCharacterClass] = useState("");
+  const [race, setRace] = useState("");
+  const [level, setLevel] = useState("1");
+  const [currentHp, setCurrentHp] = useState("");
+  const [maxHp, setMaxHp] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const resetForm = () => {
+    setName("");
+    setCharacterClass("");
+    setRace("");
+    setLevel("1");
+    setCurrentHp("");
+    setMaxHp("");
+    setError(null);
+  };
+
+  const handleModalClose = () => {
+    if (isSubmitting) {
+      return;
+    }
+    setIsModalOpen(false);
+    resetForm();
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!name.trim()) {
+      setError("Enter a character name.");
+      return;
+    }
+
+    const levelValue = level.trim() ? Number.parseInt(level, 10) : undefined;
+
+    if (levelValue !== undefined && (Number.isNaN(levelValue) || levelValue < 1 || levelValue > 20)) {
+      setError("Level must be between 1 and 20.");
+      return;
+    }
+
+    const currentHpValue = currentHp.trim() ? Number.parseInt(currentHp, 10) : undefined;
+    const maxHpValue = maxHp.trim() ? Number.parseInt(maxHp, 10) : undefined;
+
+    if (currentHpValue !== undefined && (Number.isNaN(currentHpValue) || currentHpValue < 0)) {
+      setError("Current HP must be zero or higher.");
+      return;
+    }
+
+    if (maxHpValue !== undefined && (Number.isNaN(maxHpValue) || maxHpValue < 1)) {
+      setError("Max HP must be at least 1.");
+      return;
+    }
+
+    if (currentHpValue !== undefined && maxHpValue !== undefined && currentHpValue > maxHpValue) {
+      setError("Current HP cannot exceed max HP.");
+      return;
+    }
+
+    const stats: Record<string, number> = {};
+    if (currentHpValue !== undefined) {
+      stats.current_hp = currentHpValue;
+    }
+    if (maxHpValue !== undefined) {
+      stats.max_hp = maxHpValue;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await postJson(`/api/campaigns/${campaignId}/pcs`, {
+        name: name.trim(),
+        class: characterClass.trim(),
+        race: race.trim(),
+        level: levelValue,
+        stats: Object.keys(stats).length > 0 ? stats : undefined
+      });
+
+      onMutated();
+      setIsModalOpen(false);
+      resetForm();
+    } catch (pcError) {
+      setError(pcError instanceof Error ? pcError.message : "Unable to add character");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Card className="bg-slate-900/60">
+        <CardHeader className="mb-4 flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <CardTitle>Player characters</CardTitle>
+            <CardDescription>Track the heroes at your table.</CardDescription>
+          </div>
+          {canManage ? (
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => {
+                setError(null);
+                setIsModalOpen(true);
+              }}
+            >
+              Add character
+            </Button>
+          ) : null}
+        </CardHeader>
+        <div className="space-y-4">
+          {canManage ? null : (
+            <p className="rounded-md border border-dashed border-slate-800 bg-slate-900/40 p-3 text-xs text-slate-500">
+              Only campaign owners and co-DMs can add player characters.
+            </p>
+          )}
+          <div className="space-y-3 text-sm text-slate-300">
+            {pcs.length === 0 ? (
+              <EmptyStateMessage message="No characters logged yet." />
+            ) : (
+              pcs.map((pc) => {
+                const details = [pc.class ?? undefined, pc.race ?? undefined].filter(Boolean).join(" • ");
+                const health = getPcHealth(pc.stats);
+                const hasHealth = health.currentHp !== null || health.maxHp !== null;
+
+                return (
+                  <div key={pc.id} className="space-y-2 rounded-lg border border-slate-800 bg-slate-950/60 p-4">
+                    <div className="flex items-center justify-between">
+                      <p className="text-sm font-medium text-slate-100">{pc.name}</p>
+                      <span className="text-xs uppercase tracking-wide text-slate-500">Level {pc.level ?? 1}</span>
+                    </div>
+                    <p className="text-xs text-slate-500">{details || "Class & ancestry pending"}</p>
+                    {hasHealth ? (
+                      <p className="text-xs text-slate-400">
+                        HP: {health.currentHp ?? "?"}
+                        {health.maxHp !== null ? ` / ${health.maxHp}` : ""}
+                      </p>
+                    ) : (
+                      <p className="text-xs text-slate-500">HP not recorded</p>
+                    )}
+                  </div>
+                );
+              })
+            )}
+          </div>
+        </div>
+      </Card>
+      <Modal open={isModalOpen} onClose={handleModalClose} title="Add player character">
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1 text-sm">
+              <label htmlFor="pc-name" className="text-xs uppercase tracking-wide text-slate-400">
+                Name
+              </label>
+              <Input
+                id="pc-name"
+                placeholder="E.g. Lyra Stonesong"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+            <div className="space-y-1 text-sm">
+              <label htmlFor="pc-level" className="text-xs uppercase tracking-wide text-slate-400">
+                Level
+              </label>
+              <Input
+                id="pc-level"
+                type="number"
+                min={1}
+                max={20}
+                value={level}
+                onChange={(event) => setLevel(event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1 text-sm">
+              <label htmlFor="pc-class" className="text-xs uppercase tracking-wide text-slate-400">
+                Class
+              </label>
+              <Input
+                id="pc-class"
+                placeholder="Wizard, Fighter..."
+                value={characterClass}
+                onChange={(event) => setCharacterClass(event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+            <div className="space-y-1 text-sm">
+              <label htmlFor="pc-race" className="text-xs uppercase tracking-wide text-slate-400">
+                Ancestry
+              </label>
+              <Input
+                id="pc-race"
+                placeholder="Elf, Tiefling..."
+                value={race}
+                onChange={(event) => setRace(event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1 text-sm">
+              <label htmlFor="pc-current-hp" className="text-xs uppercase tracking-wide text-slate-400">
+                Current HP
+              </label>
+              <Input
+                id="pc-current-hp"
+                type="number"
+                min={0}
+                value={currentHp}
+                onChange={(event) => setCurrentHp(event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+            <div className="space-y-1 text-sm">
+              <label htmlFor="pc-max-hp" className="text-xs uppercase tracking-wide text-slate-400">
+                Max HP
+              </label>
+              <Input
+                id="pc-max-hp"
+                type="number"
+                min={1}
+                value={maxHp}
+                onChange={(event) => setMaxHp(event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+          </div>
+          {error ? <p className="text-xs text-rose-400">{error}</p> : null}
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="secondary" onClick={handleModalClose} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Adding..." : "Save character"}
+            </Button>
+          </div>
+        </form>
+      </Modal>
+    </>
+  );
+}

--- a/components/dashboard/sections/quests-section.tsx
+++ b/components/dashboard/sections/quests-section.tsx
@@ -1,0 +1,252 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
+import { Textarea } from "@/components/ui/textarea";
+import { postJson } from "@/lib/api";
+import type { Location, Quest } from "@/types/database";
+
+import { EmptyStateMessage } from "../empty-state-message";
+
+import { selectClassName } from "./shared";
+
+interface QuestsSectionProps {
+  campaignId: string;
+  canManage: boolean;
+  quests: Quest[];
+  locations: Location[];
+  locationLookup: Map<string, string>;
+  onMutated: () => void;
+}
+
+export function QuestsSection({ campaignId, canManage, quests, locations, locationLookup, onMutated }: QuestsSectionProps) {
+  const [title, setTitle] = useState("");
+  const [summary, setSummary] = useState("");
+  const [status, setStatus] = useState<Quest["status"]>("planned");
+  const [locationId, setLocationId] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const questStatuses: Array<Quest["status"]> = ["planned", "active", "completed"];
+
+  const resetForm = () => {
+    setTitle("");
+    setSummary("");
+    setStatus("planned");
+    setLocationId("");
+    setError(null);
+  };
+
+  const handleModalClose = () => {
+    if (isSubmitting) {
+      return;
+    }
+    setIsModalOpen(false);
+    resetForm();
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!title.trim()) {
+      setError("Add a quest title to continue.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await postJson(`/api/campaigns/${campaignId}/quests`, {
+        title: title.trim(),
+        summary: summary.trim(),
+        status,
+        location_id: locationId ? locationId : null
+      });
+
+      onMutated();
+      setIsModalOpen(false);
+      resetForm();
+    } catch (questError) {
+      setError(questError instanceof Error ? questError.message : "Unable to save quest");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleGenerate = () => {
+    const quest = generateRandomQuest();
+    setTitle(quest.title);
+    setSummary(quest.summary);
+    setStatus("planned");
+    setError(null);
+  };
+
+  return (
+    <>
+      <Card className="bg-slate-900/60">
+        <CardHeader className="mb-4 flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <CardTitle>Quest log</CardTitle>
+            <CardDescription>Outline objectives and side stories.</CardDescription>
+          </div>
+          {canManage ? (
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => {
+                setError(null);
+                setIsModalOpen(true);
+              }}
+            >
+              Add quest
+            </Button>
+          ) : null}
+        </CardHeader>
+        <div className="space-y-4">
+          {canManage ? null : (
+            <p className="rounded-md border border-dashed border-slate-800 bg-slate-900/40 p-3 text-xs text-slate-500">
+              Only campaign owners and co-DMs can add quests.
+            </p>
+          )}
+          <div className="space-y-3 text-sm text-slate-300">
+            {quests.length === 0 ? (
+              <EmptyStateMessage message="No quests logged yet." />
+            ) : (
+              quests.map((quest) => (
+                <div key={quest.id} className="space-y-1 rounded-lg border border-slate-800 bg-slate-950/60 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-sm font-medium text-slate-100">{quest.title}</p>
+                    <span className="text-xs uppercase tracking-wide text-slate-500">{quest.status}</span>
+                  </div>
+                  {quest.summary ? <p className="text-xs text-slate-500">{quest.summary}</p> : null}
+                  {quest.location_id ? (
+                    <p className="text-xs text-slate-500">
+                      Location: {locationLookup.get(quest.location_id) ?? "Unknown"}
+                    </p>
+                  ) : null}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </Card>
+      <Modal open={isModalOpen} onClose={handleModalClose} title="Add quest">
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="flex items-center justify-between gap-2">
+            <p className="text-xs text-slate-500">Need a hook fast? Generate an idea.</p>
+            <Button type="button" variant="secondary" size="sm" onClick={handleGenerate} disabled={isSubmitting}>
+              Roll inspiration
+            </Button>
+          </div>
+          <div className="space-y-1 text-sm">
+            <label htmlFor="quest-title" className="text-xs uppercase tracking-wide text-slate-400">
+              Title
+            </label>
+            <Input
+              id="quest-title"
+              placeholder="E.g. Rescue the River King"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="space-y-1 text-sm">
+            <label htmlFor="quest-summary" className="text-xs uppercase tracking-wide text-slate-400">
+              Summary
+            </label>
+            <Textarea
+              id="quest-summary"
+              placeholder="Why does this quest matter?"
+              value={summary}
+              onChange={(event) => setSummary(event.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1 text-sm">
+              <label htmlFor="quest-status" className="text-xs uppercase tracking-wide text-slate-400">
+                Status
+              </label>
+              <select
+                id="quest-status"
+                className={selectClassName}
+                value={status}
+                onChange={(event) => setStatus(event.target.value as Quest["status"])}
+                disabled={isSubmitting}
+              >
+                {questStatuses.map((value) => (
+                  <option key={value} value={value}>
+                    {value}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="space-y-1 text-sm">
+              <label htmlFor="quest-location" className="text-xs uppercase tracking-wide text-slate-400">
+                Linked location
+              </label>
+              <select
+                id="quest-location"
+                className={selectClassName}
+                value={locationId}
+                onChange={(event) => setLocationId(event.target.value)}
+                disabled={isSubmitting}
+              >
+                <option value="">No location</option>
+                {locations.map((location) => (
+                  <option key={location.id} value={location.id}>
+                    {location.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          {error ? <p className="text-xs text-rose-400">{error}</p> : null}
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="secondary" onClick={handleModalClose} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Saving..." : "Save quest"}
+            </Button>
+          </div>
+        </form>
+      </Modal>
+    </>
+  );
+}
+
+const questTitleVerbs = ["Rescue", "Recover", "Protect", "Investigate", "Disrupt"] as const;
+const questTitleNouns = [
+  "the Moonlit Relic",
+  "the River King",
+  "the Whispered Vault",
+  "the Ember Crown",
+  "the Shattered Sigil"
+] as const;
+
+const questSummaries = [
+  "Rumors point to a forgotten shrine where the key to the next arc lies hidden.",
+  "A rival faction threatens the region unless someone stands in their way.",
+  "An ally has vanished after following cryptic visions of the future.",
+  "A powerful artifact has awakened and draws dangerous attention.",
+  "A village seeks aid before ancient wards collapse and unleash something terrible."
+] as const;
+
+function pickRandom<T>(values: readonly T[]): T {
+  return values[Math.floor(Math.random() * values.length)];
+}
+
+function generateRandomQuest() {
+  const title = `${pickRandom(questTitleVerbs)} ${pickRandom(questTitleNouns)}`;
+  return {
+    title,
+    summary: pickRandom(questSummaries)
+  };
+}

--- a/components/dashboard/sections/session-tracker.tsx
+++ b/components/dashboard/sections/session-tracker.tsx
@@ -1,0 +1,198 @@
+"use client";
+
+import { useState, type FormEvent } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Modal } from "@/components/ui/modal";
+import { Textarea } from "@/components/ui/textarea";
+import { postJson } from "@/lib/api";
+import { formatDateLabel, getNoteSortValue } from "@/lib/campaign-utils";
+import type { Location, Note } from "@/types/database";
+
+import { EmptyStateMessage } from "../empty-state-message";
+
+import { selectClassName } from "./shared";
+
+interface SessionTrackerProps {
+  campaignId: string;
+  canManage: boolean;
+  notes: Note[];
+  locations: Location[];
+  locationLookup: Map<string, string>;
+  onMutated: () => void;
+}
+
+export function SessionTracker({
+  campaignId,
+  canManage,
+  notes,
+  locations,
+  locationLookup,
+  onMutated
+}: SessionTrackerProps) {
+  const [sessionDate, setSessionDate] = useState("");
+  const [locationId, setLocationId] = useState("");
+  const [content, setContent] = useState("");
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+
+  const sortedNotes = [...notes].sort((a, b) => getNoteSortValue(a) - getNoteSortValue(b));
+
+  const resetForm = () => {
+    setSessionDate("");
+    setLocationId("");
+    setContent("");
+    setError(null);
+  };
+
+  const handleModalClose = () => {
+    if (isSubmitting) {
+      return;
+    }
+    setIsModalOpen(false);
+    resetForm();
+  };
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+
+    if (!content.trim()) {
+      setError("Add a quick summary before saving.");
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+
+    try {
+      await postJson(`/api/campaigns/${campaignId}/notes`, {
+        content: content.trim(),
+        session_date: sessionDate || undefined,
+        location_id: locationId ? locationId : null
+      });
+
+      onMutated();
+      setIsModalOpen(false);
+      resetForm();
+    } catch (noteError) {
+      setError(noteError instanceof Error ? noteError.message : "Unable to save note");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      <Card className="bg-slate-900/60">
+        <CardHeader className="mb-4 flex flex-wrap items-center justify-between gap-2">
+          <div>
+            <CardTitle>Session tracker</CardTitle>
+            <CardDescription>Log each session recap and follow your campaign&apos;s momentum.</CardDescription>
+          </div>
+          {canManage ? (
+            <Button
+              type="button"
+              size="sm"
+              onClick={() => {
+                setError(null);
+                setIsModalOpen(true);
+              }}
+            >
+              Add session recap
+            </Button>
+          ) : null}
+        </CardHeader>
+        <div className="space-y-4">
+          {canManage ? null : (
+            <p className="rounded-md border border-dashed border-slate-800 bg-slate-900/40 p-3 text-xs text-slate-500">
+              Only campaign owners and co-DMs can add session recaps.
+            </p>
+          )}
+          {sortedNotes.length === 0 ? (
+            <EmptyStateMessage message="No sessions logged yet—add your first recap to start the timeline." />
+          ) : (
+            <ol className="list-decimal space-y-4 pl-5 text-sm text-slate-300 marker:text-brand-light">
+              {sortedNotes.map((note, index) => (
+                <li key={note.id} className="space-y-2 rounded-lg border border-slate-800 bg-slate-950/60 p-4">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <p className="text-sm font-semibold text-white">Session {index + 1}</p>
+                    <span className="text-xs uppercase tracking-wide text-slate-500">
+                      {formatDateLabel(note.session_date)}
+                    </span>
+                  </div>
+                  {note.location_id ? (
+                    <p className="text-xs uppercase tracking-wide text-slate-500">
+                      Location: {locationLookup.get(note.location_id) ?? "Unknown location"}
+                    </p>
+                  ) : null}
+                  <p className="whitespace-pre-line text-sm text-slate-300">{note.content}</p>
+                </li>
+              ))}
+            </ol>
+          )}
+        </div>
+      </Card>
+      <Modal open={isModalOpen} onClose={handleModalClose} title="Log session recap">
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-1 text-sm">
+              <label htmlFor="note-session-date" className="text-xs uppercase tracking-wide text-slate-400">
+                Session date
+              </label>
+              <Input
+                id="note-session-date"
+                type="date"
+                value={sessionDate}
+                onChange={(event) => setSessionDate(event.target.value)}
+                disabled={isSubmitting}
+              />
+            </div>
+            <div className="space-y-1 text-sm">
+              <label htmlFor="note-location" className="text-xs uppercase tracking-wide text-slate-400">
+                Location (optional)
+              </label>
+              <select
+                id="note-location"
+                className={selectClassName}
+                value={locationId}
+                onChange={(event) => setLocationId(event.target.value)}
+                disabled={isSubmitting}
+              >
+                <option value="">No location</option>
+                {locations.map((location) => (
+                  <option key={location.id} value={location.id}>
+                    {location.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+          </div>
+          <div className="space-y-1 text-sm">
+            <label htmlFor="note-content" className="text-xs uppercase tracking-wide text-slate-400">
+              Session recap
+            </label>
+            <Textarea
+              id="note-content"
+              placeholder="Summarize key events, discoveries, and hooks."
+              value={content}
+              onChange={(event) => setContent(event.target.value)}
+              disabled={isSubmitting}
+            />
+          </div>
+          {error ? <p className="text-xs text-rose-400">{error}</p> : null}
+          <div className="flex justify-end gap-2">
+            <Button type="button" variant="secondary" onClick={handleModalClose} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? "Saving..." : "Save recap"}
+            </Button>
+          </div>
+        </form>
+      </Modal>
+    </>
+  );
+}

--- a/components/dashboard/sections/shared.ts
+++ b/components/dashboard/sections/shared.ts
@@ -1,0 +1,2 @@
+export const selectClassName =
+  "w-full rounded-md border border-slate-700 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand disabled:opacity-50";

--- a/components/dashboard/stat-card.tsx
+++ b/components/dashboard/stat-card.tsx
@@ -1,0 +1,37 @@
+"use client";
+
+import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface StatCardProps {
+  label: string;
+  value: number;
+  description: string;
+}
+
+export function StatCard({ label, value, description }: StatCardProps) {
+  return (
+    <Card>
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-sm font-medium uppercase tracking-wide text-slate-400">{label}</CardTitle>
+        <p className="text-3xl font-semibold text-white">{value}</p>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+    </Card>
+  );
+}
+
+interface QuickFactCardProps {
+  label: string;
+  value: number;
+}
+
+export function QuickFactCard({ label, value }: QuickFactCardProps) {
+  return (
+    <Card className="bg-slate-900/50">
+      <CardHeader className="space-y-1">
+        <CardTitle className="text-sm font-medium uppercase tracking-wide text-slate-400">{label}</CardTitle>
+        <p className="text-2xl font-semibold text-white">{value}</p>
+      </CardHeader>
+    </Card>
+  );
+}

--- a/components/dashboard/types.ts
+++ b/components/dashboard/types.ts
@@ -1,0 +1,19 @@
+import type {
+  Campaign,
+  CampaignMember,
+  Encounter,
+  EncounterMonster,
+  Profile
+} from "@/types/database";
+
+export interface CampaignWithRole extends Campaign {
+  membership_role: CampaignMember["role"];
+}
+
+export interface CampaignMemberWithProfile extends CampaignMember {
+  profile: Pick<Profile, "id" | "display_name" | "email"> | null;
+}
+
+export interface EncounterWithMonsters extends Encounter {
+  encounter_monsters: EncounterMonster[];
+}

--- a/components/ui/modal.tsx
+++ b/components/ui/modal.tsx
@@ -1,0 +1,91 @@
+"use client";
+
+import { useEffect, useMemo, type ReactNode, useCallback } from "react";
+import { createPortal } from "react-dom";
+
+import { cn } from "@/lib/utils";
+
+interface ModalProps {
+  open: boolean;
+  onClose: () => void;
+  title?: string;
+  description?: string;
+  children: ReactNode;
+  className?: string;
+}
+
+export function Modal({ open, onClose, title, description, children, className }: ModalProps) {
+  const portalTarget = useMemo(() => {
+    if (typeof document === "undefined") {
+      return null;
+    }
+    return document.body;
+  }, []);
+
+  useEffect(() => {
+    if (!open) {
+      return;
+    }
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        onClose();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open, onClose]);
+
+  const handleOverlayClick = useCallback(() => {
+    onClose();
+  }, [onClose]);
+
+  if (!open || !portalTarget) {
+    return null;
+  }
+
+  return createPortal(
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/80 px-4 py-6">
+      <button
+        type="button"
+        className="absolute inset-0 h-full w-full cursor-default"
+        aria-hidden="true"
+        onClick={handleOverlayClick}
+      />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={title ? "modal-title" : undefined}
+        aria-describedby={description ? "modal-description" : undefined}
+        className={cn(
+          "relative z-10 w-full max-w-lg rounded-lg border border-slate-800 bg-slate-900 p-6 text-left shadow-xl",
+          className
+        )}
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="space-y-4">
+          {(title || description) && (
+            <div className="space-y-2">
+              {title ? (
+                <h2 id="modal-title" className="text-xl font-semibold text-white">
+                  {title}
+                </h2>
+              ) : null}
+              {description ? (
+                <p id="modal-description" className="text-sm text-slate-400">
+                  {description}
+                </p>
+              ) : null}
+            </div>
+          )}
+          {children}
+        </div>
+      </div>
+    </div>,
+    portalTarget
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,26 @@
+export async function postJson<T = unknown>(path: string, payload: unknown): Promise<T> {
+  const response = await fetch(path, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json"
+    },
+    body: JSON.stringify(payload)
+  });
+
+  if (!response.ok) {
+    let message = "Unexpected error";
+
+    try {
+      const data = await response.json();
+      if (data && typeof data.error === "string") {
+        message = data.error;
+      }
+    } catch {
+      // ignore body parsing errors
+    }
+
+    throw new Error(message);
+  }
+
+  return (await response.json()) as T;
+}

--- a/lib/campaign-utils.ts
+++ b/lib/campaign-utils.ts
@@ -1,0 +1,60 @@
+import type { CampaignMember, Note, Pc } from "@/types/database";
+
+export function truncate(value: string, maxLength: number) {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength).trimEnd()}...`;
+}
+
+export function formatDateLabel(value: string | null) {
+  if (!value) {
+    return "Date pending";
+  }
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) {
+    return value;
+  }
+  return parsed.toLocaleDateString(undefined, {
+    month: "short",
+    day: "numeric",
+    year: "numeric"
+  });
+}
+
+export function formatRole(role: CampaignMember["role"]) {
+  return role
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+export function getNoteSortValue(note: Note) {
+  if (note.session_date) {
+    const time = getTime(note.session_date);
+    if (time) {
+      return time;
+    }
+  }
+  return getTime(note.created_at);
+}
+
+export function getPcHealth(stats: Pc["stats"]) {
+  if (!stats || typeof stats !== "object") {
+    return { currentHp: null, maxHp: null };
+  }
+
+  const record = stats as Record<string, unknown>;
+  const current = record.current_hp;
+  const maximum = record.max_hp;
+
+  return {
+    currentHp: typeof current === "number" ? current : null,
+    maxHp: typeof maximum === "number" ? maximum : null
+  };
+}
+
+export function getTime(value: string) {
+  const parsed = new Date(value).getTime();
+  return Number.isNaN(parsed) ? 0 : parsed;
+}


### PR DESCRIPTION
## Summary
- refactor the dashboard shell to compose campaign statistics, creation, and deletion flows from smaller building blocks
- introduce a campaign resource grid with dedicated components for session notes, characters, npcs, locations, quests, and encounters
- extract shared helpers for posting JSON requests and campaign formatting utilities for reuse across the new modules

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d38e9e5f1083249abbc33a6e41409e